### PR TITLE
Quick fix for test failing on Windows.

### DIFF
--- a/t/output.t
+++ b/t/output.t
@@ -13,6 +13,6 @@ sub bar { foo("bar") }
 bar(2);
 
 like $html, qr/match.*bar\(2\)/;
-like $html, qr!t/output\.t line 8.*\n.*in main::foo!;
+like $html, qr!t[\\/]output\.t line 8.*\n.*in main::foo!;
 
 done_testing;


### PR DESCRIPTION
Changed regex to match / or \ in output.t.
This allows the test to pass under Windows.
